### PR TITLE
[#28] Rails 6 deprecation warning with file option

### DIFF
--- a/lib/nestive-rails/layout_helper.rb
+++ b/lib/nestive-rails/layout_helper.rb
@@ -98,7 +98,7 @@ module NestiveRails
       # Capture the content to be placed inside the extended layout
       @view_flow.get(:layout).replace capture(&block).to_s
 
-      render file: layout
+      render template: layout
     end
 
     # Defines an area of content in your layout that can be modified or replaced


### PR DESCRIPTION
Use `render template: '<PATH>'` instead of `render file: '<PATH>'`. This prevents the deprecation warning from https://github.com/rails/rails/commit/c7820d8124c854760a4d288334f185de2fb99446
 
Resolves #28